### PR TITLE
Restore export folder preference support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -72,7 +72,17 @@ class dks_ruv_addon_prefs(bpy.types.AddonPreferences):
         option_save_before_export : bpy.props.BoolProperty(
                 name="Save Before Export",
                 default=True,
-        )     
+        )
+        option_export_folder : bpy.props.StringProperty(
+                name="Custom Export Folder",
+                description=(
+                        "Optional folder that overrides the temporary export "
+                        "location. Leave empty to use Blender's temporary "
+                        "directory."
+                ),
+                subtype='DIR_PATH',
+                default="",
+        )
         option_display_type : bpy.props.EnumProperty(
                 items=[('Buttons', "Buttons", "Use Buttons"),('Menu', "Menu", "Append a Menu to Main Menu"),('Hide', "Import/Export", "Use only Import/Export Menu's"),],
                 name="Display Type",
@@ -88,7 +98,8 @@ class dks_ruv_addon_prefs(bpy.types.AddonPreferences):
 
                 box=layout.box()
                 export_dir = dks_ruv.get_export_directory()
-                box.label(text="Temporary export folder:")
+                box.label(text="Export folder:")
+                box.prop(self, 'option_export_folder')
                 box.label(text=str(export_dir), icon='FILE_FOLDER')
                 box.operator("dks_ruv.open_export_directory", icon='FILEBROWSER')
                 box.prop(self, 'option_save_before_export')


### PR DESCRIPTION
## Summary
- reintroduce the custom export folder preference so legacy installs no longer error
- resolve the export directory through the preference when set, with a safe fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6f2cad4c8323bba5dd622fbae07a