### PR TITLE
Fix export directory helper and remove save-before-export toggle

### DIFF
--- a/dks_ruv.py
+++ b/dks_ruv.py
@@ -306,9 +306,6 @@ class dks_ruv_export(bpy.types.Operator):
             obj.select_set(True)
         context.view_layer.objects.active = active
 
-        if prefs.option_save_before_export:
-            bpy.ops.wm.save_mainfile()
-
         bpy.ops.export_scene.fbx(
             filepath=str(export_file),
             use_selection=True,


### PR DESCRIPTION
## Summary
- ensure the RizomUV export directory helper is available to the preferences UI
- remove the unused "Save Before Export" preference and its behaviour during export

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68da773bd648832388a0930be937905b