### PR TITLE
Restore deprecated export folder preference to avoid errors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -93,6 +93,14 @@ class dks_ruv_addon_prefs(bpy.types.AddonPreferences):
                 default=r"C:\Program Files\Rizom Lab\RizomUV 2025.0\rizomuv.exe",
         )
 
+        # NOTE: Blender may still reference this deprecated property when
+        # loading stored preferences from previous versions of the add-on.
+        # Keeping the definition avoids attribute errors during registration.
+        option_export_folder : bpy.props.StringProperty(  # type: ignore[assignment]
+                name="Deprecated export folder",
+                options={'HIDDEN'},
+        )
+
         def draw(self, context):
 
                 layout = self.layout


### PR DESCRIPTION
## Summary
- reintroduce a hidden `option_export_folder` preference so legacy Blender settings no longer raise attribute errors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da97b030948323a995da68107a1f57